### PR TITLE
Change conda and pip dependency handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,7 @@ install:
 before_script:
   - conda create -n test-env -c conda-forge -c defaults -c cpape --use-local elf
   - conda activate test-env
-  - conda install -c conda-forge -c defaults -c cpape nifty
-  - conda install -c conda-forge -c defaults z5py
+  # we still need to install zarr and pyn5, because they are not included by conda
   - conda install -c conda-forge -c defaults zarr
   - pip install pyn5
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     {% for dep in data['install_requires'] %}
     - {{ dep.lower() }}
     {% endfor %}
-    {% for dep in data['extras_require']['all'] %}
+    {% for dep in data['extras_require']['conda'] %}
     - {{ dep.lower() }}
     {% endfor %}
 

--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -31,7 +31,7 @@ requirements:
     {% for dep in data['install_requires'] %}
     - {{ dep.lower() }}
     {% endfor %}
-    {% for dep in data['extras_require']['conda'] %}
+    {% for dep in data['extras_require']['conda_all'] %}
     - {{ dep.lower() }}
     {% endfor %}
 

--- a/setup.py
+++ b/setup.py
@@ -2,34 +2,34 @@ import runpy
 import itertools
 from setuptools import setup, find_packages
 
-__version__ = runpy.run_path('elf/__version__.py')['__version__']
+__version__ = runpy.run_path("elf/__version__.py")["__version__"]
 
 requires = [
     "numpy",
     "imageio",
     "scikit-image",
-    "skan"
+    "skan",
+    "h5py",
+    "zarr"
 ]
 
-extras = {
-    "hdf5": ["h5py"],
-    "zarr": ["zarr"],
-    "vigra": ["vigra"],  # conda-only
-    "nifty": ["nifty"],  # conda-only; name clash w/ different PyPI package
-    # "n5": ["pyn5"],  # PyPI-only
-}
+# extras that are only available on conda
+extras_conda = ["vigra", "nifty", "z5py"]
+# extras that are only available on pip
+extras_pip = ["pyn5"]
 
-extras["all"] = list(itertools.chain.from_iterable(extras.values()))
+extras = {"conda": extras_conda, "pip": extras_pip}
+
 
 setup(
-    name='elf',
-    packages=find_packages(exclude=['test']),
+    name="elf",
+    packages=find_packages(exclude=["test"]),
     version=__version__,
-    author='Constantin Pape',
+    author="Constantin Pape",
     install_requires=requires,
     extras_require=extras,
-    url='https://github.com/constantinpape/elf',
-    license='MIT'
+    url="https://github.com/constantinpape/elf",
+    license="MIT"
     # we will probably have scripts at some point, so I am leaving this for reference
     # entry_points={
     #     "console_scripts": ["view_container = heimdall.scripts.view_container:main"]

--- a/setup.py
+++ b/setup.py
@@ -8,18 +8,32 @@ requires = [
     "numpy",
     "imageio",
     "scikit-image",
-    "skan",
-    "h5py",
-    "zarr"
+    "skan"
 ]
 
-# extras that are only available on conda
-extras_conda = ["vigra", "nifty", "z5py"]
-# extras that are only available on pip
-extras_pip = ["pyn5"]
 
-extras = {"conda": extras_conda, "pip": extras_pip}
+# optional dependencies for setuptools
+extras = {
+    "hdf5": "h5py",
+    "zarr": "zarr",
+    "n5": "pyn5"
+}
 
+# dependencies only available via conda,
+# we still collect them here, because the conda recipe
+# gets it's requirements from setuptools.
+conda_only = ["vigra", "nifty", "z5py"]
+
+# collect all dependencies for conda
+conda_exclude = [
+    "zarr",  # we don't need zarr dependencies in conda, because we use z5py
+    "pyn5"  # pyn5 is not available on conda (and not needed due to z5py)
+]
+conda_all = conda_only + [v for v in extras.values() if v not in conda_exclude]
+extras["conda_all"] = conda_all
+
+# NOTE in case we want to support different conda flavors at some point, we
+# can add keys to 'extras', e.g. 'conda_no_hdf5' without h5py
 
 setup(
     name="elf",


### PR DESCRIPTION
Suggestion to handle conda only and pip only dependencies, see also #2.
This solution misuses the `extra_requirements` a bit, but this would be fine with me.

I have already tested the build in conda and this seems to work.

Whoever installs this with setuptools now can only use the `"pip"` extra requirements.